### PR TITLE
Update openai_api.py

### DIFF
--- a/RyuzakiLib/hackertools/openai_api.py
+++ b/RyuzakiLib/hackertools/openai_api.py
@@ -175,7 +175,6 @@ class OpenAiToken:
         need_auth_cookies: Optional[bool] = False,
         is_different: Optional[bool] = False
     ):
-        global continue_conversations, list_user_agent
         if continue_conversations is None:
             continue_conversations = []
         if is_authorization:


### PR DESCRIPTION
when you pass a mutable object (like a list) as an argument to a function and modify it inside the function, the changes are reflected outside the function. Therefore, you don't need the global keyword in this case.